### PR TITLE
Add HTTP basic auth

### DIFF
--- a/lib/event_logger/logger.rb
+++ b/lib/event_logger/logger.rb
@@ -3,9 +3,11 @@ require "json"
 
 module EventLogger
   class Logger
-    def initialize(application:, environment:, host:, type: "event", fake_requests: false)
+    def initialize(application:, environment:, host:, username:, password:, type: "event", fake_requests: false)
       @application = application
       @environment = environment
+      @username = username
+      @password = password
       @host = host
       @type = type
       @fake_requests = fake_requests
@@ -23,6 +25,7 @@ module EventLogger
       client = Net::HTTP.new(uri.host, uri.port)
       headers = { "User-Agent" => "AlphaSightsEventLogger/#{EventLogger::Logger} (+https://github.com/alphasights/event_logger)", "Accept" => "application/json" }
       post = Net::HTTP::Post.new(uri, headers)
+      post.basic_auth(@username, @password)
       client.use_ssl = uri.scheme == "https"
 
       client.request(post, JSON.generate(data))

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -9,10 +9,12 @@ class TestLogger < Minitest::Test
       application: "brazil",
       environment: "development",
       host: "https://elasticsearch.dev:9200",
+      username: "foo",
+      password: "bar",
     )
 
     expected_json = %q({"interaction_id":12345,"type":"analyst_picked_up","timestamp":"2012-01-02T03:04:05-06:00","twilio_code":"12345","attempts":2,"advisor":{"name":"John Bohn","email":"jjbohn@gmail.com","phone":"555-521-6937"},"client":{"name":"A Client","email":"client@example.com","phone":"555-344-1790"},"analyst":{"name":"Sandy Reid","email":"the.sandy@alphasights.com","phone":"555-813-8113"},"application":"brazil","environment":"development"})
-     stub_request(:post, "https://elasticsearch.dev:9200/data/event").
+     stub_request(:post, "https://foo:bar@elasticsearch.dev:9200/data/event").
        with(body: expected_json,
             headers: {"Accept" => "application/json",
                       "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
@@ -34,6 +36,8 @@ class TestLogger < Minitest::Test
       application: "brazil",
       environment: "development",
       host: "https://elasticsearch.dev:9200",
+      username: "foo",
+      password: "bar",
       fake_requests: true,
     )
 


### PR DESCRIPTION
Long story short, Net http was removing the HTTP basic auth, which is why the requests stopped going through brazil when I added auth to the url.